### PR TITLE
Updating URLs to github.io domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,12 +246,12 @@
 
     <div id="alert" class=hidden>
       <p>Just to let you know, this is an <span style="color: red; font-style: italic">unofficial</span> version of the Liberator site. The official version is
-        at <a href="http://clojure-liberator.github.com/">http://clojure-liberator.github.com/</a>. </p>
+        at <a href="http://clojure-liberator.github.io/">http://clojure-liberator.github.io/</a>. </p>
       <p style="font-size: smaller"><a href="javascript:hide_alert()">Hide</a></p>
     </div>
 
     <script>
-      if (location.hostname != "clojure-liberator.github.com") {
+      if (location.hostname != "clojure-liberator.github.io") {
       show_alert();
       }
     </script>


### PR DESCRIPTION
....

I've updated the warning to only display when you're not on the github.io page instead of the github.com page. They have changed the domain of sites hosted to the dedicated github.io domain for security reasons. https://github.com/blog/1452-new-github-pages-domain-github-io
